### PR TITLE
Use default date formats, default warn to yellow

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -84,7 +84,7 @@ button > i.glyphicon {
 }
 
 .label-warning {
-    background-color: #3a87ad;
+    background-color: #ffd700;
 }
 
 .label-normal,

--- a/static/js/controllers.js
+++ b/static/js/controllers.js
@@ -77,7 +77,7 @@ alertaControllers.controller('AlertListController', ['$scope', '$route', '$locat
         flapping: '#FF5555',
         major: '#FF9955',
         minor: '#DDDD55',
-        warning: '#5599FF',
+        warning: '#DDDD55',
         indeterminate: 'silver',
         cleared: '#55CC55',
         normal: '#55CC55',
@@ -154,16 +154,16 @@ alertaControllers.controller('AlertListController', ['$scope', '$route', '$locat
         $scope.refreshText = 'Auto Update: On';
       }
     };
-    
+
     $scope.checkSelectAll = function() {
       if ($scope.selectAll){
         $scope.autoRefresh = false;
-        $scope.refreshText = 'Auto Update: Off';  
+        $scope.refreshText = 'Auto Update: Off';
       }else{
         $scope.autoRefresh = true;
         $scope.refreshText = 'Auto Update: On';
       }
-      
+
       var filteredAlerts = filterFilter($scope.alerts, $scope.search);
       angular.forEach(filteredAlerts, function(alert){
         alert.selected = $scope.selectAll;
@@ -506,8 +506,6 @@ alertaControllers.controller('AlertDetailController', ['$scope', '$route', '$rou
       });
     };
 
-    $scope.shortTime = config.dates && config.dates.shortTime || 'HH:mm';
-    $scope.longDate = config.dates && config.dates.longDate || 'd/M/yyyy h:mm:ss.sss a';
   }]);
 
 alertaControllers.controller('AlertTop10Controller', ['$scope', '$location', '$timeout', 'Count', 'Environment', 'Service', 'Alert',
@@ -646,7 +644,7 @@ alertaControllers.controller('AlertWatchController', ['$scope', '$route', '$loca
         critical: '#FF5555',
         major: '#FF9955',
         minor: '#DDDD55',
-        warning: '#5599FF',
+        warning: '#DDDD55',
         indeterminate: 'silver',
         cleared: '#55CC55',
         normal: '#55CC55',
@@ -849,7 +847,6 @@ alertaControllers.controller('UserController', ['$scope', '$route', '$timeout', 
       $scope.users = response.users;
     });
 
-    $scope.longDate = config.dates && config.dates.longDate || 'd/M/yyyy h:mm:ss.sss a';
   }]);
 
 alertaControllers.controller('CustomerController', ['$scope', '$route', '$timeout', '$auth', 'Customers',
@@ -910,7 +907,6 @@ alertaControllers.controller('ApiKeyController', ['$scope', '$route', '$timeout'
       $scope.keys = response.keys;
     });
 
-    $scope.longDate = config.dates && config.dates.longDate || 'd/M/yyyy h:mm:ss.sss a';
   }]);
 
 alertaControllers.controller('ProfileController', ['$scope', '$auth',
@@ -956,7 +952,6 @@ alertaControllers.controller('AboutController', ['$scope', '$timeout', 'config',
       }
     });
 
-    $scope.longDate = config.dates && config.dates.longDate || 'd/M/yyyy h:mm:ss.sss a';
   }]);
 
 alertaControllers.controller('LoginController', ['$scope', '$rootScope', '$location', '$auth', 'config',

--- a/static/js/filters.js
+++ b/static/js/filters.js
@@ -156,3 +156,20 @@ alertaFilters.filter('relativeDate', function() {
       };
     });
 
+
+
+alertaFilters.filter('round', function() {
+  return function(text, amount) {
+    if(amount === undefined) {
+      amount = 2
+    }
+
+    var num = +parseFloat(text).toFixed(amount)
+
+    // Ignore anything that isn't strictly a float, even if it appears to be, i.e. 12.3abc
+    if(isNaN(text % 1) || text % 1 === 0) {
+      return text
+    }
+    return num
+  };
+});

--- a/static/partials/alert-details.html
+++ b/static/partials/alert-details.html
@@ -48,7 +48,7 @@
         <tr><td><b>Environment</b></td><td>{{ alert.environment }}</td></tr>
         <tr><td><b>Origin</b></td><td>{{ alert.origin }}</td></tr>
         <tr ng-show="isCustomerViews();"><td><b>Customer</b></td><td>{{ alert.customer }}</td></tr>
-        <tr><td><b>Value</b></td><td>{{ alert.value }}</td></tr>
+        <tr><td><b>Value</b></td><td>{{ alert.value|round }}</td></tr>
         <tr><td><b>Text</b></td><td><span ng-bind-html="alert.text | linky:'_blank'"></span></td></tr>
         <tr><td><b>Correlate</b></td><td>{{ alert.correlate.join(', ') }}</td></tr>
         <tr><td><b>Group</b></td><td>{{ alert.group }}</td></tr>

--- a/static/partials/alert-list.html
+++ b/static/partials/alert-list.html
@@ -78,7 +78,7 @@
           <td class="hidden-xs">{{ alert.service.join(', ') }}</td>
           <td>{{ alert.resource }}</td>
           <td>{{ alert.event }}</td>
-          <td class="hidden-xs">{{ alert.value }}</td>
+          <td class="hidden-xs">{{ alert.value|round }}</td>
           <td ng-click="click($event,alert);" class="text-center"><i class="glyphicon glyphicon-menu-right" aria-hidden="true"></i></td>
         </tr>
       </table>


### PR DESCRIPTION
This means you can't format dates in config.js, but it should actually read i18n leaving it up to the user. Also yellow for warning seems to be the consensus for a default value.